### PR TITLE
Integrar suporte a modelos locais via Ollama (Llama 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ We provide a built-in diagnostic script to ensure your environment is correctly 
 
 - **LLM Configuration:**
   - [Gemini API Setup Guide](./doc/infra/gemini-setup.md)
-  - [Local LLM (Ollama) Setup Guide](./doc/infra/ollama-setup.md)
+  - [Local LLM (Ollama) Setup Guide](./doc/guias/local-llm-setup.md)
 - **Developer Tutorials:**
-  - [LLM Integration Tutorial](./doc/infra/ollama-setup.md)
+  - [LLM Integration Tutorial](./doc/tutorials/llm-integration.md)
 
 ## 📖 Usage & Interfaces
 

--- a/doc/guias/local-llm-setup.md
+++ b/doc/guias/local-llm-setup.md
@@ -1,0 +1,154 @@
+# Local LLM Setup Guide (Ollama)
+
+This guide explains how to set up and use **local** Large Language Models (via [Ollama](https://ollama.com)) in the Personal AI Core, eliminating dependency on paid APIs during development and testing.
+
+> **When to use local LLMs?**
+> - During active development (to avoid API costs)
+> - Offline integration testing
+> - Experimenting with different open-source models
+
+---
+
+## 1. Prerequisites
+
+| Requirement | Recommended Minimum |
+|---|---|
+| RAM | 8 GB (for Llama 3 8B) |
+| Free Storage | 6 GB (for Llama 3 model) |
+| OS | Windows 10/11, macOS 12+, Ubuntu 20.04+ |
+| GPU (Optional) | NVIDIA with CUDA — significantly accelerates performance |
+
+---
+
+## 2. Automated Setup (Recommended)
+
+### Windows (PowerShell)
+
+```powershell
+# From the project root
+.\scripts\setup_local_llm.ps1
+```
+
+### Linux / macOS (bash)
+
+```bash
+# From the project root
+bash scripts/setup_local_llm.sh
+```
+
+**The script will:**
+1. Check for/install Ollama.
+2. Download the default model (`llama3`).
+3. Update your `.env` with `LLM_PROVIDER=ollama`.
+4. Verify server connectivity.
+
+---
+
+## 3. Manual Setup
+
+### 1. Install Ollama
+
+- **Windows/macOS:** Download the installer from [ollama.com](https://ollama.com)
+- **Linux:**
+  ```bash
+  curl -fsSL https://ollama.com/install.sh | sh
+  ```
+
+### 2. Download a Model
+
+```bash
+# Llama 3 (recommended — good balance of quality/speed)
+ollama pull llama3
+
+# Mistral (faster, smaller)
+ollama pull mistral
+
+# CodeLlama (better for code generation)
+ollama pull codellama
+```
+
+### 3. Start Ollama Server
+
+Ensure the Ollama application is running (check system tray) or run:
+```bash
+ollama serve
+```
+> Server will be available at `http://localhost:11434`
+
+### 4. Configure `.env`
+
+Edit your `.env` file in the project root:
+
+```env
+LLM_PROVIDER=ollama
+OLLAMA_MODEL=llama3
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+### 5. Restart the Backend
+
+```bash
+npm run dev:backend
+```
+
+You should see in the console:
+```
+[LLM] Provider: ollama | Model: llama3 | URL: http://localhost:11434
+[LLM] Ollama available at http://localhost:11434
+```
+
+---
+
+## 4. Switching Between Providers
+
+Edit your `.env` and restart the backend:
+
+```env
+# Switch back to Google AI (Default)
+LLM_PROVIDER=google
+
+# Use local Ollama
+LLM_PROVIDER=ollama
+```
+
+---
+
+## 5. Recommended Models
+
+| Model | Command | RAM | Use Case |
+|---|---|---|---|
+| **llama3** | `ollama pull llama3` | 8 GB | General purpose (Default) |
+| **mistral** | `ollama pull mistral` | 5 GB | Faster responses |
+| **codellama** | `ollama pull codellama` | 8 GB | Code generation |
+| **llama3:70b** | `ollama pull llama3:70b` | 48 GB | High quality (GPU recommended) |
+
+---
+
+## ⚠️ Known Limitations
+
+### Function Calling (Tools)
+Smaller local models might not correctly support **function calling** (using tools like `get_todays_calendar_events`).
+
+- **llama3** — partial tool support (may work for simple tools)
+- **mistral** — unstable tool support
+- **codellama** — not recommended for tool use
+
+> **Recommendation:** To test complex tool flows (Google Calendar, Tasks), use the `google` provider. For conversation and RAG, Ollama works great.
+
+### Latency
+Local models on CPU are significantly slower:
+- NVIDIA GPU: 1-5 seconds per response
+- CPU only: 10-60 seconds per response
+
+---
+
+## Troubleshooting
+
+- **Error: `Ollama is not available at http://localhost:11434`**
+  - Check if `ollama serve` is running.
+  - Test connectivity: `curl http://localhost:11434/api/tags`
+- **Error: `ValueError: Unknown provider`**
+  - Verify `LLM_PROVIDER` in your `.env`. Accepted values: `google`, `ollama`.
+- **Model not responding / timeout**
+  - Ensure you have enough RAM for the selected model.
+  - Try a smaller model (`mistral` instead of `llama3`).

--- a/doc/tutorials/llm-integration.md
+++ b/doc/tutorials/llm-integration.md
@@ -24,15 +24,10 @@ import os
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
 
-def get_llm():
-    provider = os.getenv("LLM_PROVIDER", "gemini")
-    
-    if provider == "gemini":
-        return ChatGoogleGenerativeAI(model="gemini-1.5-pro")
-    elif provider == "ollama":
-        return ChatOllama(model="llama3")
-    else:
-        raise ValueError(f"Unsupported provider: {provider}")
+from app.core.llm_factory import get_llm
+
+# O sistema utiliza a factory centralizada:
+llm = get_llm()
 ```
 
 ## 2. Using LLMs in LangGraph Nodes


### PR DESCRIPTION
This PR implements local LLM support using Ollama, integrated with the existing LangGraph architecture. It includes a provider factory, automation scripts for setup, comprehensive unit tests, and updated documentation. It also ensures that the application remains functional even if the Ollama service is offline by implementing a non-blocking health check.

Fixes #1

---
*PR created automatically by Jules for task [16618947140446766998](https://jules.google.com/task/16618947140446766998) started by @luismarquitti*