### PR TITLE
🧹 Remove unused List import in rag_engine.py

### DIFF
--- a/app/tools/rag_engine.py
+++ b/app/tools/rag_engine.py
@@ -1,6 +1,6 @@
 import os
 import yaml
-from typing import List, Optional, Dict, Any
+from typing import Optional, Dict, Any
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_google_genai import GoogleGenerativeAIEmbeddings


### PR DESCRIPTION
This PR removes an unused `List` import from the `typing` module in `app/tools/rag_engine.py`. This is a trivial code health improvement that improves readability and maintainability by cleaning up dead code in the imports.

🎯 **What:** The unused `List` typing import was removed.
💡 **Why:** To reduce clutter and follow best practices for code health.
✅ **Verification:** Manually verified the file content and confirmed that `List` was not used elsewhere in the file. Attempted to run tests, but dependencies were missing in the environment; however, this change is safe as it only affects unused typing imports.
✨ **Result:** Cleaner code in `app/tools/rag_engine.py`.

---
*PR created automatically by Jules for task [15026230529870843557](https://jules.google.com/task/15026230529870843557) started by @luismarquitti*